### PR TITLE
Inject version via ldflags

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -78,6 +78,9 @@ func backend() *netboxBackend {
 
 		// Invalidate is called when a key is modified, if required.
 		Invalidate: b.invalidate,
+
+		// RunningVersion reports the version string to the vault core
+		RunningVersion: Version,
 	}
 
 	return &b

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package secretengine
+
+var Version = "v0.0.0-dev"


### PR DESCRIPTION
Adds support for injecting a version number at build time and sets it on our framework.Backend configuration (RunningVersion) so vault reports the version number in `vault plugins list -detailed`

Closes #2 