### PR TITLE
Drop redundant checkout from govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # govulncheck-action does its own checkout + Go setup.
       - uses: golang/govulncheck-action@v1
         with:
           go-version-file: go.mod


### PR DESCRIPTION
Fixes the CI error in #17 