### PR TITLE
Fix/v2 tokens

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -83,7 +83,7 @@ func backend() *netboxBackend {
 		Invalidate: b.invalidate,
 
 		// RunningVersion reports the version string to the vault core
-		RunningVersion: Version,
+		RunningVersion: version,
 	}
 
 	return &b

--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"golang.org/x/mod/semver"
 )
 
 type netboxClient struct {
@@ -202,7 +203,33 @@ func (c *netboxClient) resolveUserID(ctx context.Context, username string) (int,
 }
 
 func (c *netboxClient) getTokenContract(ctx context.Context) (TokenContract, error) {
-	return UnknownContract, nil
+	data := struct {
+		NetboxVersion string `json:"netbox-version"`
+	}{}
+
+	err := c.doRequest(ctx, "GET", "/api/status/", nil, &data)
+	if err != nil {
+		return UnknownContract, err
+	}
+
+	if data.NetboxVersion == "" {
+		return UnknownContract, errUnknownContract
+	}
+
+	version := "v" + data.NetboxVersion
+
+	if !semver.IsValid(version) {
+		return UnknownContract, errUnknownContract
+	}
+
+	switch {
+	case semver.Compare(version, "v4.5.0") < 0:
+		return OldContract, nil
+	case semver.Compare(version, "v4.6.1") < 0:
+		return NewContractNoV2, nil
+	default:
+		return NewContract, nil
+	}
 }
 
 type TokenContract int

--- a/client.go
+++ b/client.go
@@ -201,6 +201,19 @@ func (c *netboxClient) resolveUserID(ctx context.Context, username string) (int,
 	return data.Results[0].ID, nil
 }
 
+func (c *netboxClient) getTokenContract(ctx context.Context) (TokenContract, error) {
+	return UnknownContract, nil
+}
+
+type TokenContract int
+
+const (
+	UnknownContract TokenContract = iota
+	OldContract
+	NewContractNoV2
+	NewContract
+)
+
 var (
 	errNetboxNotConfigured  = errors.New("netbox backend not configured")
 	errBuildingRequest      = errors.New("bad request")
@@ -211,4 +224,5 @@ var (
 	errUserNotFound         = errors.New("user not found")
 	errUnexpectedNumResults = errors.New("unexpected number of results")
 	errWrongUser            = errors.New("query returned wrong user")
+	errUnknownContract      = errors.New("unknown token api contract")
 )

--- a/client.go
+++ b/client.go
@@ -202,43 +202,43 @@ func (c *netboxClient) resolveUserID(ctx context.Context, username string) (int,
 	return data.Results[0].ID, nil
 }
 
-func (c *netboxClient) getTokenContract(ctx context.Context) (TokenContract, error) {
+func (c *netboxClient) getTokenContract(ctx context.Context) (tokenContract, error) {
 	data := struct {
 		NetboxVersion string `json:"netbox-version"`
 	}{}
 
 	err := c.doRequest(ctx, "GET", "/api/status/", nil, &data)
 	if err != nil {
-		return UnknownContract, err
+		return unknownContract, err
 	}
 
 	if data.NetboxVersion == "" {
-		return UnknownContract, errUnknownContract
+		return unknownContract, errUnknownContract
 	}
 
 	version := "v" + data.NetboxVersion
 
 	if !semver.IsValid(version) {
-		return UnknownContract, errUnknownContract
+		return unknownContract, errUnknownContract
 	}
 
 	switch {
 	case semver.Compare(version, "v4.5.0") < 0:
-		return OldContract, nil
+		return oldContract, nil
 	case semver.Compare(version, "v4.6.1") < 0:
-		return NewContractNoV2, nil
+		return newContractNoV2, nil
 	default:
-		return NewContract, nil
+		return newContract, nil
 	}
 }
 
-type TokenContract int
+type tokenContract int
 
 const (
-	UnknownContract TokenContract = iota
-	OldContract
-	NewContractNoV2
-	NewContract
+	unknownContract tokenContract = iota
+	oldContract
+	newContractNoV2
+	newContract
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -149,7 +149,8 @@ func (c *netboxClient) doRequest(ctx context.Context, method string, path string
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return fmt.Errorf("%w: %d %s", errUnexpectedStatus, resp.StatusCode, http.StatusText(resp.StatusCode))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512)) // truncate — Django debug 500s can be huge
+		return fmt.Errorf("%w: %d %s: %s", errUnexpectedStatus, resp.StatusCode, http.StatusText(resp.StatusCode), body)
 	}
 
 	if output != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -131,68 +131,68 @@ func TestClient_GetVersionContract(t *testing.T) {
 		name         string
 		simResponse  string
 		simStatus    int
-		wantContract TokenContract
+		wantContract tokenContract
 		wantErr      error
 		breakServer  bool
 	}{
 		{
 			name:         "old contract",
 			simResponse:  `{"netbox-version": "3.7.8"}`,
-			wantContract: OldContract,
+			wantContract: oldContract,
 			wantErr:      nil,
 		},
 		{
 			name:         "old contract boundary",
 			simResponse:  `{"netbox-version": "4.4.10"}`,
-			wantContract: OldContract,
+			wantContract: oldContract,
 			wantErr:      nil,
 		},
 		{
 			name:         "partial new contract boundary",
 			simResponse:  `{"netbox-version": "4.5.0"}`,
-			wantContract: NewContractNoV2,
+			wantContract: newContractNoV2,
 			wantErr:      nil,
 		},
 		{
 			name:         "partial new contract2",
 			simResponse:  `{"netbox-version": "4.6.0"}`,
-			wantContract: NewContractNoV2,
+			wantContract: newContractNoV2,
 			wantErr:      nil,
 		},
 		{
 			name:         "fully working new contract boundary",
 			simResponse:  `{"netbox-version": "4.6.1"}`,
-			wantContract: NewContract,
+			wantContract: newContract,
 			wantErr:      nil,
 		},
 		{
 			name:         "fully working new contract",
 			simResponse:  `{"netbox-version": "4.6.2"}`,
-			wantContract: NewContract,
+			wantContract: newContract,
 			wantErr:      nil,
 		},
 		{
 			name:         "missing version",
 			simResponse:  `{}`,
-			wantContract: UnknownContract,
+			wantContract: unknownContract,
 			wantErr:      errUnknownContract,
 		},
 		{
 			name:         "malformed version",
 			simResponse:  `{"netbox-version": "broken"}`,
-			wantContract: UnknownContract,
+			wantContract: unknownContract,
 			wantErr:      errUnknownContract,
 		},
 		{
 			name:         "malformed json",
 			simResponse:  `{"netbox-version" "4.0.0"}`,
-			wantContract: UnknownContract,
+			wantContract: unknownContract,
 			wantErr:      errInvalidResponseBody,
 		},
 		{
 			name:         "server error",
 			simStatus:    500,
-			wantContract: UnknownContract,
+			wantContract: unknownContract,
 			wantErr:      errUnexpectedStatus,
 		},
 		{

--- a/client_test.go
+++ b/client_test.go
@@ -8,10 +8,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestResolveUserID(t *testing.T) {
+func TestClient_ResolveUserID(t *testing.T) {
 	tests := []struct {
 		name        string
 		username    string
@@ -90,8 +91,10 @@ func TestResolveUserID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// A stand-in NetBox that always returns one user.
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/api/users/users/") {
+					t.Errorf("got %q, want /api/users/users/", r.URL.Path)
+				}
 				w.Header().Set("Content-Type", "application/json")
 				if tt.simStatus != 0 {
 					w.WriteHeader(tt.simStatus)
@@ -120,4 +123,121 @@ func TestResolveUserID(t *testing.T) {
 		})
 	}
 
+}
+
+func TestClient_GetVersionContract(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		simResponse  string
+		simStatus    int
+		wantContract TokenContract
+		wantErr      error
+		breakServer  bool
+	}{
+		{
+			name:         "old contract",
+			simResponse:  `{"netbox-version": "3.7.8"}`,
+			wantContract: OldContract,
+			wantErr:      nil,
+		},
+		{
+			name:         "old contract boundary",
+			simResponse:  `{"netbox-version": "4.4.10"}`,
+			wantContract: OldContract,
+			wantErr:      nil,
+		},
+		{
+			name:         "partial new contract boundary",
+			simResponse:  `{"netbox-version": "4.5.0"}`,
+			wantContract: NewContractNoV2,
+			wantErr:      nil,
+		},
+		{
+			name:         "partial new contract2",
+			simResponse:  `{"netbox-version": "4.6.0"}`,
+			wantContract: NewContractNoV2,
+			wantErr:      nil,
+		},
+		{
+			name:         "fully working new contract boundary",
+			simResponse:  `{"netbox-version": "4.6.1"}`,
+			wantContract: NewContract,
+			wantErr:      nil,
+		},
+		{
+			name:         "fully working new contract",
+			simResponse:  `{"netbox-version": "4.6.2"}`,
+			wantContract: NewContract,
+			wantErr:      nil,
+		},
+		{
+			name:         "missing version",
+			simResponse:  `{}`,
+			wantContract: UnknownContract,
+			wantErr:      errUnknownContract,
+		},
+		{
+			name:         "malformed version",
+			simResponse:  `{"netbox-version": "broken"}`,
+			wantContract: UnknownContract,
+			wantErr:      errUnknownContract,
+		},
+		{
+			name:         "malformed json",
+			simResponse:  `{"netbox-version" "4.0.0"}`,
+			wantContract: UnknownContract,
+			wantErr:      errInvalidResponseBody,
+		},
+		{
+			name:         "server error",
+			simStatus:    500,
+			wantContract: UnknownContract,
+			wantErr:      errUnexpectedStatus,
+		},
+		{
+			name:      "auth failure",
+			simStatus: 403,
+			wantErr:   errUnexpectedStatus,
+		},
+		{
+			name:        "transport failure",
+			wantErr:     errRequestFailure,
+			breakServer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/status/" {
+					t.Errorf("got path %q, want /api/status/", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if tt.simStatus != 0 {
+					w.WriteHeader(tt.simStatus)
+				}
+				w.Write([]byte(tt.simResponse))
+			}))
+			defer srv.Close()
+
+			if tt.breakServer {
+				srv.Close()
+			}
+
+			client, err := newClient(&netboxConfig{URL: srv.URL, Token: "test"})
+			if err != nil {
+				t.Fatalf("got %v, want nil", err)
+			}
+
+			contract, err := client.getTokenContract(context.Background())
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got %v, want %v", err, tt.wantErr)
+			}
+			if contract != tt.wantContract {
+				t.Errorf("got %v, want %v", contract, tt.wantContract)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/hashicorp/vault/sdk v0.25.1
+	golang.org/x/mod v0.35.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/helpers_assert_test.go
+++ b/helpers_assert_test.go
@@ -141,3 +141,17 @@ func assertDescription(t *testing.T, role string, body map[string]any) {
 		t.Fatalf("want= %v, got=%v", want, got)
 	}
 }
+
+func assertMissing(t *testing.T, body map[string]any, key string) {
+	t.Helper()
+	if _, ok := body[key]; ok {
+		t.Fatalf("got %v, want %q not present", body, key)
+	}
+}
+
+func assertPresent(t *testing.T, body map[string]any, key string) {
+	t.Helper()
+	if _, ok := body[key]; !ok {
+		t.Fatalf("got %v, want %q present", body, key)
+	}
+}

--- a/path_creds.go
+++ b/path_creds.go
@@ -160,3 +160,8 @@ func generateTokenKey() (string, error) {
 	}
 	return hex.EncodeToString(b), nil // 20 bytes → 40 hex chars
 }
+
+var (
+	errV2Unsupported       = errors.New("v2 token api unsupported")
+	errPepperNotConfigured = errors.New("netbox api token pepper not configured, v2 token api unavailable")
+)

--- a/path_creds.go
+++ b/path_creds.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -28,6 +29,7 @@ type netboxTokenRequest struct {
 	AllowedIPs   []string `json:"allowed_ips,omitempty"`
 	Version      int      `json:"version,omitempty"`
 	Key          string   `json:"key,omitempty"`
+	Token        string   `json:"token,omitempty"`
 }
 
 type netboxTokenResponse struct {
@@ -117,23 +119,50 @@ func (b *netboxBackend) pathCredsRead(ctx context.Context, req *logical.Request,
 		tokenRequest.AllowedIPs = role.AllowedIPs
 	}
 
-	// Optionally set Version
-	if role.Version != 0 {
-		tokenRequest.Version = role.Version
-	}
-
-	// TEMPORARY, always generate V1 token
-	token, err := generateTokenKey()
+	// Detect token contract support
+	contract, err := c.getTokenContract(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	tokenRequest.Key = token
+	// Abort if requesting version 2 on an unsupported server
+	if role.Version == 2 && contract != newContract {
+		return nil, errV2Unsupported
+	}
+
+	var secretData map[string]any
+
+	switch role.Version {
+	case 1:
+		token, err := generateTokenKey()
+		if err != nil {
+			return nil, err
+		}
+
+		// we create v1 secret, set it now
+		secretData = map[string]any{"token": token}
+
+		if contract == oldContract {
+			tokenRequest.Key = token
+		} else {
+			tokenRequest.Token = token
+			tokenRequest.Version = 1
+		}
+	case 2:
+		tokenRequest.Version = 2
+	default:
+		// This should be impossible given we control what can be set
+		// this guard is to just avoid unexpected behaviour in the future
+		return nil, errUnknownVersion
+	}
 
 	// Sent request to netbox
 	tokenResponse := netboxTokenResponse{}
 	err = c.doRequest(ctx, "POST", "/api/users/tokens/", &tokenRequest, &tokenResponse)
 	if err != nil {
+		if role.Version == 2 && errors.Is(err, errUnexpectedStatus) && strings.Contains(err.Error(), "API_TOKEN_PEPPERS") {
+			return nil, errPepperNotConfigured
+		}
 		return nil, err
 	}
 
@@ -142,10 +171,15 @@ func (b *netboxBackend) pathCredsRead(ctx context.Context, req *logical.Request,
 		return nil, errors.New("netbox didn't return a token ID")
 	}
 
-	// Build secret
-	secretData := map[string]any{"token": tokenRequest.Key} // Always returns v1 token we generated
+	// Store the token ID
 	secretInternal := map[string]any{"token_id": tokenResponse.ID}
 
+	// v2 secret only exists in response from netbox
+	if role.Version == 2 {
+		secretData = map[string]any{"token": fmt.Sprintf("nbt_%s.%s", tokenResponse.Key, tokenResponse.Token)}
+	}
+
+	// build the secret to return to Vault
 	resp := b.Secret(netboxTokenType).Response(secretData, secretInternal)
 	resp.Secret.TTL = role.TTL
 	resp.Secret.MaxTTL = role.MaxTTL
@@ -163,5 +197,6 @@ func generateTokenKey() (string, error) {
 
 var (
 	errV2Unsupported       = errors.New("v2 token api unsupported")
-	errPepperNotConfigured = errors.New("netbox api token pepper not configured, v2 token api unavailable")
+	errUnknownVersion      = errors.New("unknown version")
+	errPepperNotConfigured = errors.New("netbox api token peppers not configured, v2 token api unavailable")
 )

--- a/path_creds_test.go
+++ b/path_creds_test.go
@@ -21,7 +21,7 @@ func TestCreds_ReadTokenOK_OldContract(t *testing.T) {
 		netboxVersion string
 	}{
 		{
-			name:          "auto version",
+			name:          "unset version",
 			roleData:      map[string]any{"username": "test"},
 			wantBody:      map[string]any{"user": float64(42), "write_enabled": false},
 			handlerReturn: map[string]any{"id": 84},
@@ -312,13 +312,13 @@ func TestCreds_NewContract_V1_SendsToken(t *testing.T) {
 	assertMissing(t, gotBody, "key")
 }
 
-func TestCreds_AutoVersion_ResolvesToV1OnNew(t *testing.T) {
-	// Request an implicit v1 token against a new contract server
+func TestCreds_UnsetVersion_V1OnNewContract(t *testing.T) {
+	// Request a token with no version set against a new contract server
 	roleData := map[string]any{"username": "test"}
 	handlerReturn := map[string]any{"id": 84}
 	resp, gotBody := mintToken(t, "4.5.0", roleData, handlerReturn)
 
-	// same assertions as TestCreds_NewContract_V1_SendsToken, but our request exercises the auto-resolution branch
+	// same assertions as TestCreds_NewContract_V1_SendsToken, but our request exercises the unset-defaults-to-v1 branch
 	assertEqual(t, float64(1), gotBody["version"])
 	assertEqual(t, gotBody["token"], resp.Data["token"])
 	assertMissing(t, gotBody, "key")
@@ -346,6 +346,34 @@ func TestCreds_V2_FatalBelow461(t *testing.T) {
 		case r.URL.Path == "/api/status/":
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{"netbox-version": "4.6.0"}`))
+		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/users/tokens/" && r.Method == "POST":
+			t.Errorf("must not POST a token when v2 is unsupported by the server")
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Create a role that explicitly wants a v2 token
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 2})
+	assertOK(t, resp, err)
+
+	// Read a token
+	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert that the read failed due to v2 not being supported
+	assertFatalErr(t, resp, err, errV2Unsupported)
+}
+
+func TestCreds_V2_FatalOnOldContract(t *testing.T) {
+	// Set up a 4.4.0 mock server that predates the new token contract
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/status/":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"netbox-version": "4.4.0"}`))
 		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
 			netboxUserFound(w, r)
 		case r.URL.Path == "/api/users/tokens/" && r.Method == "POST":

--- a/path_creds_test.go
+++ b/path_creds_test.go
@@ -188,6 +188,9 @@ func TestCreds_ReadFatalWhenNetboxErrors(t *testing.T) {
 			netboxResponds500(w, r)
 		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
 			netboxUserFound(w, r)
+		case r.URL.Path == "/api/status/":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"netbox-version": "4.4.0"}`))
 		}
 	}
 

--- a/path_creds_test.go
+++ b/path_creds_test.go
@@ -12,52 +12,49 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-func TestCreds_ReadTokenOK(t *testing.T) {
+func TestCreds_ReadTokenOK_OldContract(t *testing.T) {
 	tests := []struct {
 		name          string
 		roleData      map[string]any
 		wantBody      map[string]any
 		handlerReturn map[string]any
+		netboxVersion string
 	}{
 		{
 			name:          "auto version",
 			roleData:      map[string]any{"username": "test"},
 			wantBody:      map[string]any{"user": float64(42), "write_enabled": false},
 			handlerReturn: map[string]any{"id": 84},
-		},
-		{
-			name:          "forced v1",
-			roleData:      map[string]any{"username": "test", "version": 1},
-			wantBody:      map[string]any{"user": float64(42), "write_enabled": false, "version": float64(1)},
-			handlerReturn: map[string]any{"id": 84},
+			netboxVersion: "4.4.0",
 		},
 		{
 			name:          "allowed ips",
 			roleData:      map[string]any{"username": "test", "allowed_ips": []any{"1.1.1.1/32", "10.0.0.0/24"}},
 			wantBody:      map[string]any{"user": float64(42), "write_enabled": false, "allowed_ips": []any{"1.1.1.1/32", "10.0.0.0/24"}},
 			handlerReturn: map[string]any{"id": 84},
+			netboxVersion: "4.4.0",
 		},
 		{
 			name:          "write enabled",
 			roleData:      map[string]any{"username": "test", "write_enabled": true},
 			wantBody:      map[string]any{"user": float64(42), "write_enabled": true},
 			handlerReturn: map[string]any{"id": 84},
+			netboxVersion: "4.4.0",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mint the token
-			resp, gotBody := mintToken(t, tt.roleData, tt.handlerReturn)
+			resp, gotBody := mintToken(t, tt.netboxVersion, tt.roleData, tt.handlerReturn)
 
-			// v1 tokens are created by us and sent to netbox
-			//   so we assert that the token sent to netbox was also sent to the client
-			// TODO: refactor to test the v2 shape
-			sentKey, ok := gotBody["key"].(string)
-			if !ok {
-				t.Fatalf("key not sent to netbox")
-			}
-			assertEqual(t, sentKey, resp.Data["token"].(string))
+			// assert we sent an "old contract" request
+			assertPresent(t, gotBody, "key")
+			assertMissing(t, gotBody, "version")
+			assertMissing(t, gotBody, "token")
+
+			// assert the token we sent is the one we received
+			assertEqual(t, gotBody["key"], resp.Data["token"].(string))
 			delete(gotBody, "key")
 
 			// We aren't testing the expire time
@@ -130,7 +127,7 @@ func TestCreds_ValidateExpireTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mint the token
-			_, gotBody := mintToken(t, tt.roleData, tt.handlerReturn)
+			_, gotBody := mintToken(t, "4.4.0", tt.roleData, tt.handlerReturn)
 
 			// Assert the token expire time
 			assertExpireTime(t, gotBody, tt.wantEffectiveTTL)
@@ -159,6 +156,9 @@ func TestCreds_ReadFatalWhenNotConfigured(t *testing.T) {
 
 	// Read token from test role
 	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert the read was fatal because the role was not configured
+	// TODO: replace this with a sentinel error
 	assertFatal(t, resp, err, "not configured")
 }
 
@@ -175,6 +175,8 @@ func TestCreds_ReadFatalWhenNetboxUnreachable(t *testing.T) {
 
 	// Read token from test role
 	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert the read was fatable because netbox was unreachable
 	assertFatal(t, resp, err, "request failure")
 }
 
@@ -198,6 +200,8 @@ func TestCreds_ReadFatalWhenNetboxErrors(t *testing.T) {
 
 	// Read token from test role
 	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert the read was fatal due to an unexpected status code
 	assertFatalErr(t, resp, err, errUnexpectedStatus)
 }
 
@@ -211,10 +215,14 @@ func TestCreds_ReadFatalWhenUserDeleted(t *testing.T) {
 
 	// Read token from test role
 	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert the read was fatal because the user was not found
 	assertFatalErr(t, resp, err, errUserNotFound)
 }
 
-func mintToken(t *testing.T, roleData map[string]any, handlerReturn map[string]any) (*logical.Response, map[string]any) {
+// mintToken runs a happy path test from end to end.
+// Used as a helper function in many other tests.
+func mintToken(t *testing.T, netboxVersion string, roleData map[string]any, handlerReturn map[string]any) (*logical.Response, map[string]any) {
 	// Create backend handler we can watch
 	// we will assert these after the request
 	var tokenHits int
@@ -239,8 +247,11 @@ func mintToken(t *testing.T, roleData map[string]any, handlerReturn map[string]a
 
 			// Respond to the token request
 			json.NewEncoder(w).Encode(handlerReturn)
+
 		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
 			netboxUserFound(w, r)
+		case r.URL.Path == "/api/status/" && r.Method == "GET":
+			json.NewEncoder(w).Encode(map[string]any{"netbox-version": netboxVersion})
 		default:
 			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
 		}
@@ -261,4 +272,191 @@ func mintToken(t *testing.T, roleData map[string]any, handlerReturn map[string]a
 	assertEqual(t, 1, tokenHits)
 
 	return resp, gotBody
+}
+
+func TestCreds_ReadFatalWhenVersionUndetectable(t *testing.T) {
+	// Mock netbox server that returns an invalid response for the status endpoint
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/status/" && r.Method == "GET":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Create our test role
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test"})
+	assertOK(t, resp, err)
+
+	// Read a token
+	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert the read was fatal because we couldn't detect the API contract
+	assertFatalErr(t, resp, err, errUnknownContract)
+}
+
+func TestCreds_NewContract_V1_SendsToken(t *testing.T) {
+	// Request an explicit v1 token against a new contract server
+	roleData := map[string]any{"username": "test", "version": 1}
+	handlerReturn := map[string]any{"id": 84}
+	resp, gotBody := mintToken(t, "4.5.0", roleData, handlerReturn)
+
+	// Assert that we sent a "new contract" version 1 request
+	assertEqual(t, float64(1), gotBody["version"])
+	assertEqual(t, gotBody["token"], resp.Data["token"])
+	assertMissing(t, gotBody, "key")
+}
+
+func TestCreds_AutoVersion_ResolvesToV1OnNew(t *testing.T) {
+	// Request an implicit v1 token against a new contract server
+	roleData := map[string]any{"username": "test"}
+	handlerReturn := map[string]any{"id": 84}
+	resp, gotBody := mintToken(t, "4.5.0", roleData, handlerReturn)
+
+	// same assertions as TestCreds_NewContract_V1_SendsToken, but our request exercises the auto-resolution branch
+	assertEqual(t, float64(1), gotBody["version"])
+	assertEqual(t, gotBody["token"], resp.Data["token"])
+	assertMissing(t, gotBody, "key")
+}
+
+func TestCreds_NewContract_V2(t *testing.T) {
+	// Request a v2 token against a v2 capable server
+	roleData := map[string]any{"username": "test", "version": 2}
+	handlerReturn := map[string]any{"id": 84, "key": "abc123", "token": "deadbeef"}
+	resp, gotBody := mintToken(t, "4.6.2", roleData, handlerReturn)
+
+	// Assert that we sent a v2 request
+	assertEqual(t, float64(2), gotBody["version"])
+	assertMissing(t, gotBody, "key")
+	assertMissing(t, gotBody, "token")
+
+	// Assert that we received the token that we expected
+	assertEqual(t, "nbt_abc123.deadbeef", resp.Data["token"])
+}
+
+func TestCreds_V2_FatalBelow461(t *testing.T) {
+	// Set up a 4.6.0 mock server
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/status/":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"netbox-version": "4.6.0"}`))
+		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/users/tokens/" && r.Method == "POST":
+			t.Errorf("must not POST a token when v2 is unsupported by the server")
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Create a role that explicitly wants a v2 token
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 2})
+	assertOK(t, resp, err)
+
+	// Read a token
+	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert that the read failed due to v2 not being supported
+	assertFatalErr(t, resp, err, errV2Unsupported)
+}
+
+func TestCreds_V2_FatalWhenPepperMissing(t *testing.T) {
+	// Set up a 4.6.2 mock server that doesn't have API_TOKEN_PEPERS configured
+	var posted bool
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/status/":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"netbox-version": "4.6.2"}`))
+		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/users/tokens/" && r.Method == "POST":
+			posted = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+			w.Write([]byte(`{"error":"API_TOKEN_PEPPERS is not defined","exception":"ValueError"}`))
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Create a role that explicitly requests a v2 token
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 2})
+	assertOK(t, resp, err)
+
+	// Read the token
+	resp, err = tokenRead(t, backend, storage, "test")
+
+	// Assert that the token read actually hit the api to generate the error
+	assertEqual(t, true, posted)
+
+	// Assert that the test failed due to peppers not being configured
+	assertFatalErr(t, resp, err, errPepperNotConfigured)
+}
+
+func TestCreds_VersionRedetectedPerRequest(t *testing.T) {
+	// Create a mock server that changes versions between requests
+	var statusHits int
+	var bodies []map[string]any
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/status/":
+			statusHits++
+			w.Header().Set("Content-Type", "application/json")
+			// First mint sees an old server; second sees a new one.
+			if statusHits == 1 {
+				w.Write([]byte(`{"netbox-version": "4.4.0"}`))
+			} else {
+				w.Write([]byte(`{"netbox-version": "4.5.0"}`))
+			}
+		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/users/tokens/" && r.Method == "POST":
+			body := map[string]any{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("unparseable token request: %v", err)
+			}
+			bodies = append(bodies, body)
+			// v1 never reads the secret back; only the token ID is consumed.
+			json.NewEncoder(w).Encode(map[string]any{"id": 84})
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Create a role with an implicit version
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test"})
+	assertOK(t, resp, err)
+
+	// Read two tokens
+	resp, err = tokenRead(t, backend, storage, "test")
+	assertOK(t, resp, err)
+	resp, err = tokenRead(t, backend, storage, "test")
+	assertOK(t, resp, err)
+
+	// Assert the version was re-detected on each read, not cached on the client
+	assertEqual(t, 2, statusHits)
+
+	// Assert that we got two token API hits
+	assertEqual(t, 2, len(bodies))
+
+	// Assert that the first request had an "old contract" request shape
+	assertPresent(t, bodies[0], "key")
+	assertMissing(t, bodies[0], "version")
+	assertMissing(t, bodies[0], "token")
+
+	// Assert that the second request upgraded to "new contract" v1 request
+	assertEqual(t, float64(1), bodies[1]["version"])
+	assertMissing(t, bodies[1], "key")
+	assertPresent(t, bodies[1], "token")
 }

--- a/path_role.go
+++ b/path_role.go
@@ -75,13 +75,12 @@ func pathRole(b *netboxBackend) []*framework.Path {
 					},
 				},
 				"version": {
-					Type: framework.TypeInt,
-					//Description: "Version of token to mint. Allowed values are 1, 2, or 0, which defaults to the best supported by your version of netbox. Version 2 requires Netbox 4.6.1+",
-					Description: "Version of token to mint. Allowed values are 0 or 1. Currently 0 will just default to 1 until support for v2 tokens is added.",
+					Type:        framework.TypeInt,
+					Description: "Version of token to mint. Allowed values are 1 or 2",
 					DisplayAttrs: &framework.DisplayAttributes{
 						Name: "Version",
 					},
-					AllowedValues: []any{0, 1},
+					AllowedValues: []any{1, 2},
 				},
 				"ttl": {
 					Type:        framework.TypeDurationSecond,
@@ -149,6 +148,11 @@ func getRole(ctx context.Context, s logical.Storage, name string) (*netboxRole, 
 	err = entry.DecodeJSON(&role)
 	if err != nil {
 		return nil, fmt.Errorf("error reading role %q: %w", name, err)
+	}
+
+	// Migrate legacy version 0 to default version 1
+	if role.Version == 0 {
+		role.Version = 1
 	}
 
 	// Return the role
@@ -240,18 +244,15 @@ func (b *netboxBackend) pathRoleWrite(ctx context.Context, req *logical.Request,
 	// Field: Version (not required, set default)
 	if version, ok := data.GetOk("version"); ok {
 		switch version.(int) {
-		case 0:
-			role.Version = 0
-			resp.AddWarning("token version unset; defaulting to v1 (v2 not yet supported)")
 		case 1:
 			role.Version = 1
 		case 2:
-			return logical.ErrorResponse("v2 tokens are not yet supported; use version 1 or leave unset"), nil
+			role.Version = 2
 		default:
-			return logical.ErrorResponse("version must be 0 (auto/v1) or 1"), nil
+			return logical.ErrorResponse("version must be 1 or 2"), nil
 		}
 	} else if createMode {
-		role.Version = 0 // unset → v1, no warning (see below)
+		role.Version = 1
 	}
 
 	// Field: TTL (not required, set default)

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -645,3 +645,26 @@ func TestRole_CreateErrorForVersion0(t *testing.T) {
 	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 0})
 	assertError(t, resp, err, "version must")
 }
+
+func TestRole_MigratesLegacyVersion0(t *testing.T) {
+	// Create mock backend
+	_, storage := testBackend(t)
+
+	// Simulate a v0.4.0 role stored with version 0 (auto), writing it directly
+	// to storage to bypass the write-path validation that now rejects 0
+	entry, err := logical.StorageEntryJSON(roleStoragePath("legacy"), &netboxRole{Username: "test", Version: 0})
+	if err != nil {
+		t.Fatalf("StorageEntryJSON returned err: %v", err)
+	}
+	if err := storage.Put(t.Context(), entry); err != nil {
+		t.Fatalf("storage.Put returned err: %v", err)
+	}
+
+	// Read it back; the legacy version 0 must be migrated to v1
+	role, err := getRole(t.Context(), storage, "legacy")
+	if err != nil {
+		t.Fatalf("getRole returned an error: %v", err)
+	}
+
+	assertEqual(t, 1, role.Version)
+}

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -41,6 +41,10 @@ func TestRole_CreateOKSetsFields(t *testing.T) {
 			create: map[string]any{"username": "test", "version": 1},
 		},
 		{
+			name:   "version 2",
+			create: map[string]any{"username": "test", "version": 2},
+		},
+		{
 			name:       "ttl",
 			create:     map[string]any{"username": "test", "ttl": "1h"},
 			expectNorm: map[string]any{"ttl": 1 * time.Hour},
@@ -152,8 +156,8 @@ func TestRole_UpdateOKSetsFields(t *testing.T) {
 		},
 		{
 			name:   "version",
-			create: map[string]any{"username": "test"},
-			update: map[string]any{"version": 1},
+			create: map[string]any{"username": "test"}, // defaults to v1
+			update: map[string]any{"version": 2},
 		},
 		{
 			name:       "ttl",
@@ -269,7 +273,7 @@ func TestRole_CreateOKSetsDefaults(t *testing.T) {
 
 	// Assert all default values were set as expected
 	assertDefault(t, resp, "write_enabled", false)
-	assertDefault(t, resp, "version", 0)
+	assertDefault(t, resp, "version", 1)
 	assertDefault(t, resp, "allowed_ips", []string{})
 	assertDefault(t, resp, "ttl", float64(0))
 	assertDefault(t, resp, "max_ttl", float64(0))
@@ -633,20 +637,11 @@ func TestRole_UpdateFatalWhenRoleMissing(t *testing.T) {
 	assertFatal(t, resp, err, "not found during update")
 }
 
-func TestRole_CreateWarnForVersion0(t *testing.T) {
+func TestRole_CreateErrorForVersion0(t *testing.T) {
 	// Create mock backend
 	backend, storage, _ := testBackendWithNetbox(t, netboxUserFound)
 
-	// Write the role
+	// Write the role with the now-invalid version 0 (auto was dropped)
 	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 0})
-	assertWarning(t, resp, err, "defaulting to v1")
-}
-
-func TestRole_CreateErrorForVersion2(t *testing.T) {
-	// Create mock backend
-	backend, storage, _ := testBackendWithNetbox(t, netboxUserFound)
-
-	// Write the role
-	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test", "version": 2})
-	assertError(t, resp, err, "v2 tokens are not yet supported")
+	assertError(t, resp, err, "version must")
 }

--- a/version.go
+++ b/version.go
@@ -3,4 +3,4 @@
 
 package secretengine
 
-var Version = "v0.0.0-dev"
+var version = "v0.0.0-dev"


### PR DESCRIPTION
This drops support for the "auto" token version, and implements explicit v1 and v2 token handling. If version is unset, it will default to version 1. Version 2 tokens are supported on NetBox v4.6.1+

Closes #6 
Closes #22
Closes #23