### PR TITLE
chore: migrate cosign signing to v3 bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,11 +36,10 @@ checksum:
 signs:
   - cmd: cosign
     artifacts: checksum
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     output: true

--- a/README.md
+++ b/README.md
@@ -166,16 +166,15 @@ Release binaries are signed with [cosign](https://github.com/sigstore/cosign) us
 signing, and the checksums are published as `SHA256SUMS`. Before trusting a binary you can
 verify it genuinely came from this repo's release pipeline.
 
-Download the binary you want along with `SHA256SUMS`, `SHA256SUMS.pem`, and `SHA256SUMS.sig`
+Download the binary you want along with `SHA256SUMS` and `SHA256SUMS.sigstore.json`
 from the [releases page](https://github.com/ljb2of3/vault-plugin-secrets-netbox/releases),
 then verify the signature on the checksums:
 
 ```bash
-VERSION=0.5.1    # the release you downloaded
+VERSION=0.6.0    # the release you downloaded
 
 cosign verify-blob \
-    --certificate "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS.pem" \
-    --signature "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS.sig" \
+    --bundle "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS.sigstore.json" \
     --certificate-identity "https://github.com/ljb2of3/vault-plugin-secrets-netbox/.github/workflows/release.yml@refs/tags/v${VERSION}" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
     "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS"


### PR DESCRIPTION
Bumps `sigstore/cosign-installer` 3.9.1 → 4.1.2 and migrates our signing to the Cosign v3 bundle format. Supersedes #31 (which was the bare installer bump).

## Why
cosign-installer v4 defaults to installing **Cosign v3+**. In cosign v3, `sign-blob`'s `--output-certificate` / `--output-signature` flags are deprecated in favor of a single `--bundle` output (`.sigstore.json`), and are slated for removal in cosign v4. The old flags still work under v3.x but emit deprecation warnings, so we migrate now.

## Changes
- `.github/workflows/release.yml`: pin `cosign-installer` → v4.1.2
- `.goreleaser.yml`: `signs` now uses `--bundle=${artifact}.sigstore.json` (dropped `certificate:` + the two `--output-*` flags)
- `README.md`: verification instructions now use `cosign verify-blob --bundle …sigstore.json` (no more separate `.pem`/`.sig`)

## Testing
Cutting a `v0.6.0-rc1` release to validate the new signing path end-to-end before merge. Note: releases cut after this change publish `…SHA256SUMS.sigstore.json` instead of `.pem`/`.sig`; older releases are unaffected.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)