### PR TITLE
chore: standardize help text and fix NetBox capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ vault-plugin-secrets-netbox          secret      v0.5.1
 ```bash
 vault secrets enable \
     -path netbox \
+    -description "Ephemeral NetBox API tokens" \
     vault-plugin-secrets-netbox
 ```
 6. Verify the plugin was enabled with `vault secrets list`
@@ -69,11 +70,12 @@ vault secrets enable \
 $ vault secrets list
 Path               Type                           Accessor                                Description
 ----               ----                           --------                                -----------
-agent-registry/    agent_registry                 agent-registry_d0853b2c                 agent registry
-cubbyhole/         cubbyhole                      cubbyhole_e1c288da                      per-token private secret storage
-identity/          identity                       identity_4103190e                       identity store
-netbox/            vault-plugin-secrets-netbox    vault-plugin-secrets-netbox_31d45f2d    ephemeral netbox tokens
-sys/               system                         system_81e72f2e                         system endpoints used for control, policy and debugging
+agent-registry/    agent_registry                 agent-registry_429ae6bb                 agent registry
+cubbyhole/         cubbyhole                      cubbyhole_d39bcebd                      per-token private secret storage
+identity/          identity                       identity_72c2d897                       identity store
+netbox/            vault-plugin-secrets-netbox    vault-plugin-secrets-netbox_66f0c9bb    Ephemeral NetBox API tokens
+secret/            kv                             kv_d8bca533                             key/value secret storage
+sys/               system                         system_32f65a0e                         system endpoints used for control, policy and debugging
 ```
 
 ### Configuration

--- a/backend.go
+++ b/backend.go
@@ -33,10 +33,19 @@ type netboxBackend struct {
 }
 
 const rootHelp = `
-The Netbox secrets backend dynamically generates API tokens. 
-Use config/ to set the netbox url and admin credentials with permissions to generate tokens.
-Then create a role/<name> to configure a username to generate a token for.
-Call creds/<role> to generate a token.`
+The NetBox secrets backend dynamically generates short-lived NetBox API tokens.
+
+Getting started is a three step workflow:
+
+  1. Configure the backend at config/ with the NetBox server URL and an admin
+     API token that has permission to create and delete tokens.
+  2. Define one or more roles at role/<name>, each mapping to a NetBox username
+     along with the settings (TTL, write access, allowed IPs, token version)
+     applied to tokens minted for that role.
+  3. Read creds/<role> to mint a token. Vault leases the token and revokes it
+     in NetBox when the lease expires or is revoked.
+
+See the help for each path (e.g. "vault path-help <mount>/config") for details.`
 
 // This func wires up our backend struct and provides config for our plugin
 func backend() *netboxBackend {

--- a/path_config.go
+++ b/path_config.go
@@ -25,12 +25,30 @@ type netboxConfig struct {
 }
 
 // <mount>/config
-const pathConfigHelpSynopsis = `
-Configure the Netbox backend`
+const pathConfigHelpSynopsis = `Configure the connection to NetBox.`
 
 const pathConfigHelpDescription = `
-The Netbox secret backend requires a Netbox server URL
-and credentials for creating and destroying API tokens`
+Stores the NetBox server URL and an admin API token used to mint and revoke
+tokens. This must be written before creating roles or minting tokens.
+
+Fields:
+
+  * url   (required) - Base URL of the NetBox server, e.g. https://netbox.example.
+  * token (required) - An existing NetBox API token with permission to create
+                       and delete tokens.
+  * insecure          - Skip verification of the NetBox server's TLS certificate.
+                        Defaults to false; do not enable in production.
+  * ca_cert           - PEM-encoded CA certificate that signed the NetBox
+                        server's certificate, for private CAs.
+
+Example:
+
+  vault write <mount>/config \
+      url=https://netbox.example \
+      token=<admin-token>
+
+The configuration can be partially updated by writing only the fields you want
+to change.`
 
 // pathConfig extends the Vault API with a `/config` endpoint for this backend
 func pathConfig(b *netboxBackend) *framework.Path {
@@ -42,7 +60,7 @@ func pathConfig(b *netboxBackend) *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"url": {
 				Type:        framework.TypeString,
-				Description: "The URL for the Netbox server",
+				Description: "The URL for the NetBox server",
 				Required:    true,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name:      "URL",
@@ -51,7 +69,7 @@ func pathConfig(b *netboxBackend) *framework.Path {
 			},
 			"token": {
 				Type:        framework.TypeString,
-				Description: "The token used to access Netbox",
+				Description: "The token used to access NetBox",
 				Required:    true,
 				DisplayAttrs: &framework.DisplayAttributes{
 					Name:      "Token",
@@ -60,7 +78,7 @@ func pathConfig(b *netboxBackend) *framework.Path {
 			},
 			"insecure": {
 				Type:        framework.TypeBool,
-				Description: "Disable validation of the Netbox server's TLS certificate",
+				Description: "Disable validation of the NetBox server's TLS certificate",
 				Required:    false,
 				Default:     false,
 				DisplayAttrs: &framework.DisplayAttributes{
@@ -70,7 +88,7 @@ func pathConfig(b *netboxBackend) *framework.Path {
 			},
 			"ca_cert": {
 				Type:        framework.TypeString,
-				Description: "CA certifcate that signed the Netbox server's cert",
+				Description: "CA certificate that signed the NetBox server's cert",
 				Required:    false,
 				Default:     "",
 				DisplayAttrs: &framework.DisplayAttributes{

--- a/path_creds.go
+++ b/path_creds.go
@@ -18,8 +18,19 @@ import (
 
 const netboxGracePeriod = 5 * time.Minute
 
-const pathCredsHelpSynopsis = `Mints a netbox token`
-const pathCredsListDescription = `Mints a netbox token`
+const pathCredsHelpSynopsis = `Mint a NetBox API token for a role.`
+
+const pathCredsHelpDescription = `
+Reading this path mints a new NetBox API token for the named role and returns
+it under a Vault lease. When the lease expires or is revoked, Vault deletes the
+token in NetBox.
+
+The role must already exist (see <mount>/role/<name>) and the backend must be
+configured (see <mount>/config).
+
+Example:
+
+  vault read <mount>/creds/<role>`
 
 type netboxTokenRequest struct {
 	User         int      `json:"user"`
@@ -43,8 +54,9 @@ func pathCreds(b *netboxBackend) *framework.Path {
 		Pattern: "creds/" + framework.GenericNameRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
-				Type:     framework.TypeLowerCaseString,
-				Required: true,
+				Type:        framework.TypeLowerCaseString,
+				Description: "Name of the role to mint a token for.",
+				Required:    true,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -53,7 +65,7 @@ func pathCreds(b *netboxBackend) *framework.Path {
 			},
 		},
 		HelpSynopsis:    pathCredsHelpSynopsis,
-		HelpDescription: pathCredsListDescription,
+		HelpDescription: pathCredsHelpDescription,
 	}
 }
 

--- a/path_role.go
+++ b/path_role.go
@@ -29,18 +29,38 @@ type netboxRole struct {
 }
 
 // <mount>/role/*
-const pathRoleHelpSynopsis = `
-Configure netbox roles`
+const pathRoleHelpSynopsis = `Manage roles that map Vault leases to NetBox users.`
 
 const pathRoleHelpDescription = `
-Each role maps to a specific netbox username, and has various config options. 
-Multiple roles may point at the same user with different settings.`
+Each role maps to a NetBox username and defines the settings applied to tokens
+minted for it. Multiple roles may point at the same user with different
+settings.
 
-const pathRoleListHelpSynopsis = `
-List netbox roles`
+Fields:
+
+  * username      (required) - The NetBox user that minted tokens belong to.
+  * write_enabled            - Whether minted tokens have write access.
+                               Defaults to false (read-only).
+  * allowed_ips              - Comma-separated CIDRs allowed to use the token.
+  * version                  - Token API version to mint: 1 (legacy key token)
+                               or 2 (pepper/secret token). Defaults to the
+                               server-appropriate version.
+  * ttl                      - Default lease duration for minted tokens.
+                               0 uses the system default.
+  * max_ttl                  - Maximum lease duration for minted tokens.
+                               0 uses the system default.
+
+Example:
+
+  vault write <mount>/role/<name> \
+      username=svc-account \
+      write_enabled=true \
+      ttl=1h max_ttl=24h`
+
+const pathRoleListHelpSynopsis = `List configured NetBox roles.`
 
 const pathRoleHelpListDescription = `
-Lists all configured netbox roles`
+Lists the names of all roles configured on this mount.`
 
 func pathRole(b *netboxBackend) []*framework.Path {
 	return []*framework.Path{
@@ -48,12 +68,13 @@ func pathRole(b *netboxBackend) []*framework.Path {
 			Pattern: "role/" + framework.GenericNameRegex("name"),
 			Fields: map[string]*framework.FieldSchema{
 				"name": {
-					Type:     framework.TypeLowerCaseString,
-					Required: true,
+					Type:        framework.TypeLowerCaseString,
+					Description: "Name of the role.",
+					Required:    true,
 				},
 				"username": {
 					Type:        framework.TypeString,
-					Description: "The netbox user assigned to the token minted.",
+					Description: "The NetBox user assigned to the token minted.",
 					Required:    true,
 					DisplayAttrs: &framework.DisplayAttributes{
 						Name: "username",
@@ -76,7 +97,7 @@ func pathRole(b *netboxBackend) []*framework.Path {
 				},
 				"version": {
 					Type:        framework.TypeInt,
-					Description: "Version of token to mint. Allowed values are 1 or 2",
+					Description: "Token API version to mint: 1 (legacy key token) or 2 (pepper/secret token).",
 					DisplayAttrs: &framework.DisplayAttributes{
 						Name: "Version",
 					},
@@ -284,11 +305,11 @@ func (b *netboxBackend) pathRoleWrite(ctx context.Context, req *logical.Request,
 		if err != nil {
 			switch {
 			case errors.Is(err, errNetboxNotConfigured):
-				resp.AddWarning("Netbox backend not configured. Be sure to write to /config before minting tokens.")
+				resp.AddWarning("NetBox backend not configured. Be sure to write to /config before minting tokens.")
 			case errors.Is(err, errRequestFailure):
-				resp.AddWarning(fmt.Sprintf("Unable to validate username because netbox was unreachable: %v", err))
+				resp.AddWarning(fmt.Sprintf("Unable to validate username because NetBox was unreachable: %v", err))
 			case errors.Is(err, errUserNotFound):
-				resp.AddWarning(fmt.Sprintf("%q not a valid netbox user. Create netbox user before minting tokens.", username.(string)))
+				resp.AddWarning(fmt.Sprintf("%q not a valid NetBox user. Create NetBox user before minting tokens.", username.(string)))
 			default:
 				return nil, err
 			}

--- a/path_role_test.go
+++ b/path_role_test.go
@@ -434,7 +434,7 @@ func TestRole_CreateWarnWhenNetboxUnreachable(t *testing.T) {
 	resp, err := roleCreateDefault(t, backend, storage)
 
 	// Assert we got a warning about netbox being unreachable
-	assertWarning(t, resp, err, "netbox was unreachable")
+	assertWarning(t, resp, err, "NetBox was unreachable")
 
 	// Validate role was actually written
 	role, err := getRole(t.Context(), storage, "test")
@@ -458,7 +458,7 @@ func TestRole_CreateWarnWhenNotConfigured(t *testing.T) {
 	// Write test role
 	resp, err := roleCreateDefault(t, backend, storage)
 
-	// Expect warning `Netbox backend not configured. Be sure to write to /config before minting tokens.`
+	// Expect warning `NetBox backend not configured. Be sure to write to /config before minting tokens.`
 	assertWarning(t, resp, err, "not configured")
 
 	// Validate role was actually written

--- a/secret_token.go
+++ b/secret_token.go
@@ -23,7 +23,7 @@ func (b *netboxBackend) netboxToken() *framework.Secret {
 		Fields: map[string]*framework.FieldSchema{
 			"token": {
 				Type:        framework.TypeString,
-				Description: "Netbox Token",
+				Description: "The generated NetBox API token.",
 			},
 		},
 		Revoke: b.revokeToken,


### PR DESCRIPTION
Closes #24. Closes #39.

## What
- **#24 — branding/typo:** "Netbox" → "NetBox" across all user-facing path-help, field descriptions, and role warnings. Go error strings are intentionally left lowercase (staticcheck ST1005). Fixed the `certifcate` typo in the `ca_cert` description.
- **#39 — help text:** standardized and expanded path help. Each path now has an imperative one-line synopsis plus a fuller description with field-by-field guidance and an example command (root, config, role, role-list, creds). Added descriptions for the role/creds `name` field.
- **#39 — plugin description:** `framework.Backend` has no description field; the `vault secrets list` Description column comes from the operator's `-description` flag at enable time. Added `-description "Ephemeral NetBox API tokens"` to the README enable example and **re-captured** the `vault secrets list` block so the docs are internally consistent.

## Notes
- Error strings stay lowercase: `client.go` `errNetboxNotConfigured`, `path_creds.go` token/pepper errors.
- `test/integration.sh` greps the unknown-user warning case-insensitively, so the "NetBox" change there still matches.
- Test assertion updated in lockstep: `path_role_test.go` now asserts `"NetBox was unreachable"`.

## Verification
- `gofmt`, `go vet ./...`, `staticcheck ./...` (clean — no new ST1005), `go test ./...` green.
- Built the plugin into a dev Vault and inspected rendered `vault path-help` for root/config/role/creds and `vault secrets list`; the README block is the real captured output.