### PR TITLE
docs: bump README version references to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is a Vault plugin and is meant to work with Vault. This guide assumes you h
 2. Copy the binary into the `plugin_directory` on each of your Vault servers.
 3. Use [`vault plugin register`](https://developer.hashicorp.com/vault/docs/commands/plugin/register) to add your plugin to the catalog. For example:
 ```bash
-VERSION=0.5.1    # the release you downloaded
+VERSION=0.6.0    # the release you downloaded
 SHA256=...       # this binary's entry in the verified SHA256SUMS file
 
 vault plugin register \
@@ -56,7 +56,7 @@ alicloud                             auth        v0.23.1+builtin
 approle                              auth        v2.0.2+builtin.vault
 ...                                  ...         ...
 transit                              secret      v2.0.2+builtin.vault
-vault-plugin-secrets-netbox          secret      v0.5.1
+vault-plugin-secrets-netbox          secret      v0.6.0
 ```
 5. Enable the plugin
 ```bash


### PR DESCRIPTION
Updates the two stale version references in the README to match the v0.6.0 release:

- `vault plugin register` example: `VERSION=0.5.1` → `0.6.0`
- `vault plugin list` output: plugin row `v0.5.1` → `v0.6.0`

Per the just-tweak-the-readme request, these are direct edits (no server re-capture). The example builtin-plugin versions (alicloud/approle/transit) are left as-is.