### PR TITLE
Fix/3x renew

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,23 +204,9 @@ func (c *netboxClient) resolveUserID(ctx context.Context, username string) (int,
 }
 
 func (c *netboxClient) getTokenContract(ctx context.Context) (tokenContract, error) {
-	data := struct {
-		NetboxVersion string `json:"netbox-version"`
-	}{}
-
-	err := c.doRequest(ctx, "GET", "/api/status/", nil, &data)
+	version, err := c.getVersion(ctx)
 	if err != nil {
 		return unknownContract, err
-	}
-
-	if data.NetboxVersion == "" {
-		return unknownContract, errUnknownContract
-	}
-
-	version := "v" + data.NetboxVersion
-
-	if !semver.IsValid(version) {
-		return unknownContract, errUnknownContract
 	}
 
 	switch {
@@ -231,6 +217,42 @@ func (c *netboxClient) getTokenContract(ctx context.Context) (tokenContract, err
 	default:
 		return newContract, nil
 	}
+}
+
+func (c *netboxClient) renewRequiresKey(ctx context.Context) (bool, error) {
+	version, err := c.getVersion(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if semver.Compare(version, "v4.0.10") < 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *netboxClient) getVersion(ctx context.Context) (string, error) {
+	data := struct {
+		NetboxVersion string `json:"netbox-version"`
+	}{}
+
+	err := c.doRequest(ctx, "GET", "/api/status/", nil, &data)
+	if err != nil {
+		return "", err
+	}
+
+	if data.NetboxVersion == "" {
+		return "", errUnknownContract
+	}
+
+	version := "v" + data.NetboxVersion
+
+	if !semver.IsValid(version) {
+		return "", errUnknownContract
+	}
+
+	return version, nil
 }
 
 type tokenContract int

--- a/client_test.go
+++ b/client_test.go
@@ -241,3 +241,97 @@ func TestClient_GetVersionContract(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_RenewRequiresKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		simResponse string
+		simStatus   int
+		want        bool
+		wantErr     error
+		breakServer bool
+	}{
+		{
+			name:        "yes 3.x",
+			simResponse: `{"netbox-version": "3.7.8"}`,
+			want:        true,
+			wantErr:     nil,
+		},
+		{
+			name:        "yes 4.x",
+			simResponse: `{"netbox-version": "4.0.9"}`,
+			want:        true,
+			wantErr:     nil,
+		},
+		{
+			name:        "no",
+			simResponse: `{"netbox-version": "4.0.10"}`,
+			want:        false,
+			wantErr:     nil,
+		},
+		{
+			name:        "missing version",
+			simResponse: `{}`,
+			wantErr:     errUnknownContract,
+		},
+		{
+			name:        "malformed version",
+			simResponse: `{"netbox-version": "broken"}`,
+			wantErr:     errUnknownContract,
+		},
+		{
+			name:        "malformed json",
+			simResponse: `{"netbox-version" "4.0.0"}`,
+			wantErr:     errInvalidResponseBody,
+		},
+		{
+			name:      "server error",
+			simStatus: 500,
+			wantErr:   errUnexpectedStatus,
+		},
+		{
+			name:      "auth failure",
+			simStatus: 403,
+			wantErr:   errUnexpectedStatus,
+		},
+		{
+			name:        "transport failure",
+			wantErr:     errRequestFailure,
+			breakServer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/status/" {
+					t.Errorf("got path %q, want /api/status/", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if tt.simStatus != 0 {
+					w.WriteHeader(tt.simStatus)
+				}
+				w.Write([]byte(tt.simResponse))
+			}))
+			defer srv.Close()
+
+			if tt.breakServer {
+				srv.Close()
+			}
+
+			client, err := newClient(&netboxConfig{URL: srv.URL, Token: "test"})
+			if err != nil {
+				t.Fatalf("got %v, want nil", err)
+			}
+
+			got, err := client.renewRequiresKey(context.Background())
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("got %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/helpers_backend_test.go
+++ b/helpers_backend_test.go
@@ -5,6 +5,7 @@ package secretengine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -69,4 +70,39 @@ func netboxResponds404(w http.ResponseWriter, r *http.Request) {
 func netboxResponds500(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(500)
 	w.Write([]byte{})
+}
+
+// renewHandler builds an httptest handler for renewal tests. It resolves the
+// role's user (role creation needs it), serves /api/status/ with the given
+// NetBox version (renewToken probes it via renewRequiresKey), and routes the
+// PATCH of token 42 to patch. Any other request fails the test.
+func renewHandler(t *testing.T, version string, patch http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/users/users/" && r.Method == http.MethodGet:
+			netboxUserFound(w, r)
+		case r.URL.Path == "/api/status/" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"netbox-version": %q}`, version)
+		case r.URL.Path == "/api/users/tokens/42/" && r.Method == http.MethodPatch:
+			patch(w, r)
+		default:
+			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
+		}
+	}
+}
+
+// capturePatch returns a PATCH responder that decodes the JSON request body
+// into *dst and replies 204.
+func capturePatch(t *testing.T, dst *map[string]any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+			t.Errorf("Unparseable request body: %v", err)
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(204)
+	}
 }

--- a/helpers_crud_test.go
+++ b/helpers_crud_test.go
@@ -143,27 +143,37 @@ func tokenRevoke(t *testing.T, b *netboxBackend, s logical.Storage, id int) (*lo
 }
 
 // Renew a token
-func tokenRenew(t *testing.T, b *netboxBackend, s logical.Storage, id int, role string, inc time.Duration) (*logical.Response, error) {
+func tokenRenew(t *testing.T, b *netboxBackend, s logical.Storage, id int, role string, inc time.Duration, includeKey bool) (*logical.Response, error) {
 	t.Helper()
-	return tokenRenewAt(t, b, s, id, role, inc, time.Time{})
+	return tokenRenewAt(t, b, s, id, role, inc, time.Time{}, includeKey)
 }
 
 // Renew a token issued at a specific time
-func tokenRenewAt(t *testing.T, b *netboxBackend, s logical.Storage, id int, role string, inc time.Duration, issued time.Time) (*logical.Response, error) {
+func tokenRenewAt(t *testing.T, b *netboxBackend, s logical.Storage, id int, role string, inc time.Duration, issued time.Time, includeKey bool) (*logical.Response, error) {
 	t.Helper()
 	return b.HandleRequest(t.Context(), &logical.Request{
 		Operation: logical.RenewOperation,
 		Storage:   s,
 		Secret: &logical.Secret{
-			InternalData: map[string]any{
-				"secret_type": netboxTokenType,
-				"token_id":    float64(id), // vault will internally pass a float64, so we type cast
-				"role":        role,
-			},
+			InternalData: internalData(id, role, includeKey),
 			LeaseOptions: logical.LeaseOptions{
 				Increment: inc,
 				IssueTime: issued,
 			},
 		},
 	})
+}
+
+func internalData(id int, role string, includeKey bool) map[string]any {
+	data := map[string]any{
+		"secret_type": netboxTokenType,
+		"token_id":    float64(id), // vault will internally pass a float64, so we type cast
+		"role":        role,
+	}
+
+	if includeKey {
+		data["key"] = "test"
+	}
+
+	return data
 }

--- a/path_creds.go
+++ b/path_creds.go
@@ -143,6 +143,9 @@ func (b *netboxBackend) pathCredsRead(ctx context.Context, req *logical.Request,
 	}
 
 	var secretData map[string]any
+	var secretInternal = map[string]any{
+		"role": name,
+	}
 
 	switch role.Version {
 	case 1:
@@ -156,6 +159,7 @@ func (b *netboxBackend) pathCredsRead(ctx context.Context, req *logical.Request,
 
 		if contract == oldContract {
 			tokenRequest.Key = token
+			secretInternal["key"] = token
 		} else {
 			tokenRequest.Token = token
 			tokenRequest.Version = 1
@@ -184,10 +188,7 @@ func (b *netboxBackend) pathCredsRead(ctx context.Context, req *logical.Request,
 	}
 
 	// Store the token ID
-	secretInternal := map[string]any{
-		"role":     name,
-		"token_id": tokenResponse.ID,
-	}
+	secretInternal["token_id"] = tokenResponse.ID
 
 	// v2 secret only exists in response from netbox
 	if role.Version == 2 {

--- a/path_creds_test.go
+++ b/path_creds_test.go
@@ -55,9 +55,13 @@ func TestCreds_ReadTokenOK_OldContract(t *testing.T) {
 
 			// assert the token we sent is the one we received
 			assertEqual(t, gotBody["key"], resp.Data["token"].(string))
-			delete(gotBody, "key")
 
-			// We aren't testing the expire time
+			// Assert the token was stored in case we need it to renew
+			assertPresent(t, resp.Secret.InternalData, "key")
+			assertEqual(t, gotBody["key"], resp.Secret.InternalData["key"].(string))
+
+			// Delete fields that won't appear in wantBody because they're computed
+			delete(gotBody, "key")
 			delete(gotBody, "expires")
 
 			// Assert the description
@@ -68,10 +72,12 @@ func TestCreds_ReadTokenOK_OldContract(t *testing.T) {
 			assertEqual(t, tt.wantBody, gotBody)
 
 			// Assert we got the token ID
-			assertEqual(t, tt.handlerReturn["id"].(int), resp.Secret.InternalData["token_id"])
+			assertPresent(t, resp.Secret.InternalData, "token_id")
+			assertEqual(t, tt.handlerReturn["id"].(int), resp.Secret.InternalData["token_id"].(int))
 
 			// Assert we got the role name
-			assertEqual(t, "test", resp.Secret.InternalData["role"])
+			assertPresent(t, resp.Secret.InternalData, "role")
+			assertEqual(t, "test", resp.Secret.InternalData["role"].(string))
 
 			// Assert the token is renewable
 			assertEqual(t, true, resp.Secret.Renewable)
@@ -319,6 +325,9 @@ func TestCreds_NewContract_V1_SendsToken(t *testing.T) {
 	assertEqual(t, float64(1), gotBody["version"])
 	assertEqual(t, gotBody["token"], resp.Data["token"])
 	assertMissing(t, gotBody, "key")
+
+	// Assert that the token was NOT stored
+	assertMissing(t, resp.Secret.InternalData, "key")
 }
 
 func TestCreds_UnsetVersion_V1OnNewContract(t *testing.T) {
@@ -346,6 +355,9 @@ func TestCreds_NewContract_V2(t *testing.T) {
 
 	// Assert that we received the token that we expected
 	assertEqual(t, "nbt_abc123.deadbeef", resp.Data["token"])
+
+	// Assert that the token was NOT stored
+	assertMissing(t, resp.Secret.InternalData, "key")
 }
 
 func TestCreds_V2_FatalBelow461(t *testing.T) {

--- a/secret_token.go
+++ b/secret_token.go
@@ -128,6 +128,22 @@ func (b *netboxBackend) renewToken(ctx context.Context, req *logical.Request, da
 		Expires: expires.Format(time.RFC3339),
 	}
 
+	// See if we need to include the key
+	requiresKey, err := c.renewRequiresKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if requiresKey {
+		// Do we have the key?
+		key, ok := req.Secret.InternalData["key"]
+		if !ok {
+			return nil, errRenewKeyMissing
+		}
+
+		tokenRequest.Key = key.(string)
+	}
+
 	// Fire off request to netbox
 	resp, err := c.rawRequest(ctx, "PATCH", path, tokenRequest)
 	if err != nil {
@@ -154,9 +170,11 @@ func (b *netboxBackend) renewToken(ctx context.Context, req *logical.Request, da
 
 type netboxTokenUpdateRequest struct {
 	Expires string `json:"expires"`
+	Key     string `json:"key,omitempty"`
 }
 
 var (
-	errTokenNotFound = errors.New("token not found")
-	errRoleNotFound  = errors.New("role not found")
+	errTokenNotFound   = errors.New("token not found")
+	errRoleNotFound    = errors.New("role not found")
+	errRenewKeyMissing = errors.New("renew requires key, but none was found")
 )

--- a/secret_token_test.go
+++ b/secret_token_test.go
@@ -4,7 +4,6 @@
 package secretengine
 
 import (
-	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -101,31 +100,7 @@ func TestSecretToken_RenewUpdatesNetboxExpire(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotBody map[string]any
-
-			handler := func(w http.ResponseWriter, r *http.Request) {
-				switch {
-				case r.URL.Path == "/api/users/users/" && r.Method == "GET":
-					netboxUserFound(w, r)
-				case r.URL.Path == "/api/users/tokens/42/" && r.Method == "PATCH":
-					// decode request
-					data := map[string]any{}
-					if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-						t.Errorf("Unparseable request body: %v", err)
-						w.WriteHeader(500)
-						return
-					}
-
-					// Store body so we can assert it later
-					gotBody = data
-
-					// Respond to the token request
-					w.WriteHeader(204)
-					w.Write([]byte{})
-
-				default:
-					t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
-				}
-			}
+			handler := renewHandler(t, "4.4.0", capturePatch(t, &gotBody))
 
 			// Create mock backend
 			backend, storage, _ := testBackendWithNetbox(t, handler)
@@ -135,7 +110,7 @@ func TestSecretToken_RenewUpdatesNetboxExpire(t *testing.T) {
 			assertOK(t, resp, err)
 
 			// Renew the token
-			resp, err = tokenRenew(t, backend, storage, 42, "test", tt.increment)
+			resp, err = tokenRenew(t, backend, storage, 42, "test", tt.increment, false)
 			assertOK(t, resp, err)
 
 			// Assert the token expire time
@@ -146,31 +121,7 @@ func TestSecretToken_RenewUpdatesNetboxExpire(t *testing.T) {
 
 func TestSecretToken_RenewRespectsIssueTime(t *testing.T) {
 	var gotBody map[string]any
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
-			netboxUserFound(w, r)
-		case r.URL.Path == "/api/users/tokens/42/" && r.Method == "PATCH":
-			// decode request
-			data := map[string]any{}
-			if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-				t.Errorf("Unparseable request body: %v", err)
-				w.WriteHeader(500)
-				return
-			}
-
-			// Store body so we can assert it later
-			gotBody = data
-
-			// Respond to the token request
-			w.WriteHeader(204)
-			w.Write([]byte{})
-
-		default:
-			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
-		}
-	}
+	handler := renewHandler(t, "4.4.0", capturePatch(t, &gotBody))
 
 	// Create mock backend
 	backend, storage, _ := testBackendWithNetbox(t, handler)
@@ -185,7 +136,7 @@ func TestSecretToken_RenewRespectsIssueTime(t *testing.T) {
 
 	// Renew a token that was issued 45 minutes ago
 	issued := time.Now().Add(-45 * time.Minute)
-	resp, err = tokenRenewAt(t, backend, storage, 42, "test", 0, issued)
+	resp, err = tokenRenewAt(t, backend, storage, 42, "test", 0, issued, false)
 	assertOK(t, resp, err)
 
 	// Assert the token only has the 15 minutes left on its max_ttl, not a fresh hour
@@ -204,7 +155,7 @@ func TestSecretToken_RenewFatalWhenNetboxDown(t *testing.T) {
 	srv.Close()
 
 	// Renew a token
-	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour)
+	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour, false)
 
 	// Assert that this actually failed
 	assertFatal(t, resp, err, "request failure")
@@ -216,20 +167,13 @@ func TestSecretToken_RenewFatalWhenNetboxErrors(t *testing.T) {
 	var gotMethod string
 	var hits int
 
-	// Create custom handler to error after role setup
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
-			netboxUserFound(w, r)
-		case r.URL.Path == "/api/users/tokens/42/" && r.Method == "PATCH":
-			hits++
-			gotPath = r.URL.Path
-			gotMethod = r.Method
-			netboxResponds500(w, r)
-		default:
-			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
-		}
-	}
+	// Spy on the PATCH, then respond 500
+	handler := renewHandler(t, "4.4.0", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		netboxResponds500(w, r)
+	})
 
 	// Create mock backend
 	backend, storage, _ := testBackendWithNetbox(t, handler)
@@ -239,7 +183,7 @@ func TestSecretToken_RenewFatalWhenNetboxErrors(t *testing.T) {
 	assertOK(t, resp, err)
 
 	// Renew a token
-	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour)
+	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour, false)
 	assertFatal(t, resp, err, "unexpected status")
 
 	// Assert our spy got hit and we got the correct ID and method
@@ -254,20 +198,13 @@ func TestSecretToken_RenewFatalWhenTokenNotFound(t *testing.T) {
 	var gotMethod string
 	var hits int
 
-	// Create custom handler to error after role setup
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/users/users/" && r.Method == "GET":
-			netboxUserFound(w, r)
-		case r.URL.Path == "/api/users/tokens/42/" && r.Method == "PATCH":
-			hits++
-			gotPath = r.URL.Path
-			gotMethod = r.Method
-			netboxResponds404(w, r)
-		default:
-			t.Errorf("Unexpected HTTP call %s %s", r.Method, r.URL.Path)
-		}
-	}
+	// Spy on the PATCH, then respond 404
+	handler := renewHandler(t, "4.4.0", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		netboxResponds404(w, r)
+	})
 
 	// Create mock backend
 	backend, storage, _ := testBackendWithNetbox(t, handler)
@@ -277,7 +214,7 @@ func TestSecretToken_RenewFatalWhenTokenNotFound(t *testing.T) {
 	assertOK(t, resp, err)
 
 	// Renew a token
-	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour)
+	resp, err = tokenRenew(t, backend, storage, 42, "test", 0*time.Hour, false)
 	assertFatalErr(t, resp, err, errTokenNotFound)
 
 	// Assert our spy got hit and we got the correct ID and method
@@ -288,6 +225,71 @@ func TestSecretToken_RenewFatalWhenTokenNotFound(t *testing.T) {
 
 func TestSecretToken_RenewFatalWhenRoleNotFound(t *testing.T) {
 	backend, storage := testBackend(t)
-	resp, err := tokenRenew(t, backend, storage, 42, "test", 0)
+	resp, err := tokenRenew(t, backend, storage, 42, "test", 0, false)
 	assertFatalErr(t, resp, err, errRoleNotFound)
+}
+
+func TestSecretToken_RenewSendsKeyWhenRequired(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantKey       bool
+		netboxVersion string
+	}{
+		{
+			name:          "needs key",
+			wantKey:       true,
+			netboxVersion: "3.7.8",
+		},
+		{
+			name:          "doesn't need key",
+			wantKey:       false,
+			netboxVersion: "4.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			handler := renewHandler(t, tt.netboxVersion, capturePatch(t, &gotBody))
+
+			// Create mock backend
+			backend, storage, _ := testBackendWithNetbox(t, handler)
+
+			// Write test role
+			resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test"})
+			assertOK(t, resp, err)
+
+			// Renew the token
+			resp, err = tokenRenew(t, backend, storage, 42, "test", 0, true)
+			assertOK(t, resp, err)
+
+			if tt.wantKey {
+				assertPresent(t, gotBody, "key")
+				assertEqual(t, "test", gotBody["key"].(string))
+			} else {
+				assertMissing(t, gotBody, "key")
+			}
+		})
+	}
+}
+
+func TestSecretToken_RenewFatalWhenKeyRequiredButMissing(t *testing.T) {
+	var gotBody map[string]any
+	handler := renewHandler(t, "4.0.9", capturePatch(t, &gotBody))
+
+	// Create mock backend
+	backend, storage, _ := testBackendWithNetbox(t, handler)
+
+	// Write test role
+	resp, err := roleCreate(t, backend, storage, "test", map[string]any{"username": "test"})
+	assertOK(t, resp, err)
+
+	// Renew the token
+	resp, err = tokenRenew(t, backend, storage, 42, "test", 0, false)
+	assertFatalErr(t, resp, err, errRenewKeyMissing)
+
+	// Assert no patch happened
+	if gotBody != nil {
+		t.Errorf("renew should not PATCH when the key is missing, but sent %v", gotBody)
+	}
 }


### PR DESCRIPTION
Prior to 4.0.10 Netbox generates a new token during a PATCH request if the `key` field was missing, which had the effect of rotating the key out from under us during a renew. This PR implements sending the token back to NetBox during a renew if required.

Closes #42 