### PR TITLE
docs: prepare 0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-30
+
 ### Fixed
 
 - Token renewal no longer breaks the issued token on NetBox 3.6.0–4.0.9. On those
@@ -105,7 +107,8 @@ First versioned, release-tooled build.
 - Initial release. Plugin scaffolding, the `config/` endpoint for the NetBox
   server URL and admin API token, and the NetBox API client.
 
-[Unreleased]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is a Vault plugin and is meant to work with Vault. This guide assumes you h
 2. Copy the binary into the `plugin_directory` on each of your Vault servers.
 3. Use [`vault plugin register`](https://developer.hashicorp.com/vault/docs/commands/plugin/register) to add your plugin to the catalog. For example:
 ```bash
-VERSION=0.6.0    # the release you downloaded
+VERSION=0.6.1    # the release you downloaded
 SHA256=...       # this binary's entry in the verified SHA256SUMS file
 
 vault plugin register \
@@ -56,7 +56,7 @@ alicloud                             auth        v0.23.1+builtin
 approle                              auth        v2.0.2+builtin.vault
 ...                                  ...         ...
 transit                              secret      v2.0.2+builtin.vault
-vault-plugin-secrets-netbox          secret      v0.6.0
+vault-plugin-secrets-netbox          secret      v0.6.1
 ```
 5. Enable the plugin
 ```bash
@@ -173,7 +173,7 @@ from the [releases page](https://github.com/ljb2of3/vault-plugin-secrets-netbox/
 then verify the signature on the checksums:
 
 ```bash
-VERSION=0.6.0    # the release you downloaded
+VERSION=0.6.1    # the release you downloaded
 
 cosign verify-blob \
     --bundle "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS.sigstore.json" \


### PR DESCRIPTION
Promote the Unreleased #42 renewal fix to 0.6.1 in the changelog and bump the README version references from 0.6.0 to 0.6.1.