### PR TITLE
ci: run the scheduled scan weekly instead of nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
   push:
     branches: [main]
-  # Nightly run so newly published vulnerability advisories surface on their
-  # own, instead of waiting for the next push to main. Offset from the hour
-  # because on-the-hour schedules queue behind GitHub's peak load.
+  # Weekly run so newly published vulnerability advisories surface on their
+  # own, instead of waiting for the next push to main. Monday morning, offset
+  # from the hour because on-the-hour schedules queue behind GitHub's peak
+  # load. Dependabot already opens dependency PRs weekly, so a faster cadence
+  # here would mostly re-report advisories that have a PR waiting.
   schedule:
-    - cron: "17 5 * * *"
+    - cron: "17 5 * * 1"
 
 # Least-privilege default; individual jobs add scopes if they need them.
 permissions:


### PR DESCRIPTION
Changes the scheduled CI run from nightly to Monday mornings.

The schedule was added in #55 so advisories published between pushes still get noticed, rather than sitting undetected the way GO-2026-6061 and GO-2026-5970 did. A week is soon enough for that. Dependabot already opens dependency PRs weekly, so a nightly run mostly re-reported findings that already had a PR waiting.

`17 5 * * *` becomes `17 5 * * 1`. The offset from the hour stays, because on-the-hour schedules queue behind GitHub's peak load.

Pushes and pull requests still run the full suite on every event, so this only changes how often CI runs on its own.