### PR TITLE
docs: prepare 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-08-18
+
+### Security
+
+- Rebuilt against patched dependencies and Go 1.26.6. Releases through 0.6.1
+  shipped seven advisories reachable from plugin code, in
+  `google.golang.org/grpc`, `golang.org/x/text` and the standard library. The
+  fixes are compiled into the binary, so upgrading is the only way to get them.
+
+### Changed
+
+- Building from source now requires Go 1.26.6, raised from 1.26.4.
+
 ## [0.6.1] - 2026-06-30
 
 ### Fixed
@@ -107,7 +120,8 @@ First versioned, release-tooled build.
 - Initial release. Plugin scaffolding, the `config/` endpoint for the NetBox
   server URL and admin API token, and the NetBox API client.
 
-[Unreleased]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/ljb2of3/vault-plugin-secrets-netbox/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is a Vault plugin and is meant to work with Vault. This guide assumes you h
 2. Copy the binary into the `plugin_directory` on each of your Vault servers.
 3. Use [`vault plugin register`](https://developer.hashicorp.com/vault/docs/commands/plugin/register) to add your plugin to the catalog. For example:
 ```bash
-VERSION=0.6.1    # the release you downloaded
+VERSION=0.6.2    # the release you downloaded
 SHA256=...       # this binary's entry in the verified SHA256SUMS file
 
 vault plugin register \
@@ -56,7 +56,7 @@ alicloud                             auth        v0.23.1+builtin
 approle                              auth        v2.0.2+builtin.vault
 ...                                  ...         ...
 transit                              secret      v2.0.2+builtin.vault
-vault-plugin-secrets-netbox          secret      v0.6.1
+vault-plugin-secrets-netbox          secret      v0.6.2
 ```
 5. Enable the plugin
 ```bash
@@ -173,7 +173,7 @@ from the [releases page](https://github.com/ljb2of3/vault-plugin-secrets-netbox/
 then verify the signature on the checksums:
 
 ```bash
-VERSION=0.6.1    # the release you downloaded
+VERSION=0.6.2    # the release you downloaded
 
 cosign verify-blob \
     --bundle "vault-plugin-secrets-netbox_${VERSION}_SHA256SUMS.sigstore.json" \


### PR DESCRIPTION
Changelog entry and README version bump for 0.6.2.

## Why this release is worth cutting

The fixes from #55 are already on `main`, but they only reach users through a release. Tag v0.6.1 was built with Go 1.26.4 and shipped `grpc` 1.79.3 and `x/text` 0.37.0, so all seven reachable advisories are compiled into the binaries people are running right now:

| Advisory | Component |
|---|---|
| [GO-2026-6061](https://pkg.go.dev/vuln/GO-2026-6061) | `google.golang.org/grpc` |
| [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970) | `golang.org/x/text` |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) | `crypto/tls` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |
| [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026) | `net/http` |

Rebuilding is the only way for users to pick them up, which is why the changelog entry is filed under Security rather than Changed.

## What is in the release

Everything on `main` since v0.6.1: the dependency and toolchain fixes, the x/mod bump, and CI changes that do not affect the binary.

Patch version is right. No API or behavior change. The one thing worth calling out under Changed is that building from source now needs Go 1.26.6, raised from 1.26.4.

## README

The three version references are bumped: `vault plugin register` example, `vault plugin list` output, and the cosign verification block. The `vault plugin list` block is edited directly rather than re-captured from a server, matching how 0.6.1 was prepared in 0495df0.

## After merge

Tagging `v0.6.2` triggers [release.yml](.github/workflows/release.yml), which builds, signs with cosign, and publishes. I have not tagged anything.